### PR TITLE
Add `readOnlyRootFilesystem: true` for deployments & statefulsets

### DIFF
--- a/CI/demo-api-azure-pipeline.yaml
+++ b/CI/demo-api-azure-pipeline.yaml
@@ -30,7 +30,7 @@ stages:
       inputs:
         PathtoPublish: elvia-deployment
         ArtifactName: elvia-deployment
-    
+
 - stage: DeployStable
   dependsOn: Build
   jobs:
@@ -38,7 +38,7 @@ stages:
     parameters:
       name: demo-api
       helmValuesFile: demo-api-values-stable.yaml
-    
+
 - stage: DeployProgressive
   dependsOn: DeployStable
   jobs:

--- a/CI/demo-api-values-progressive.yaml
+++ b/CI/demo-api-values-progressive.yaml
@@ -21,7 +21,7 @@ strategy:
 
 image:
   repository: containerregistryelvia.azurecr.io/core-demo-api
-  tag: "20240221.2"
+  tag: "latest-cache"
 
 imagePullSecret: containerregistryelvia
 

--- a/CI/demo-api-values-stable.yaml
+++ b/CI/demo-api-values-stable.yaml
@@ -11,7 +11,7 @@ replicaCount: 2
 
 image:
   repository: containerregistryelvia.azurecr.io/core-demo-api
-  tag: "20240221.2"
+  tag: "latest-cache"
 
 imagePullSecret: containerregistryelvia
 

--- a/elvia-deployment/templates/deployment.yaml
+++ b/elvia-deployment/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         kubectl.kubernetes.io/default-container: {{ required "Missing .Values.name" .Values.name }}
       labels:
         app: {{ required "Missing .Values.name" .Values.name }}
-        microservice-type: {{ required "Missing .Values.microserviceType" .Values.microserviceType }}        
+        microservice-type: {{ required "Missing .Values.microserviceType" .Values.microserviceType }}
         azure.workload.identity/use: "true"
     spec:
       serviceAccountName: {{ required "Missing .Values.name" .Values.name }}
@@ -80,21 +80,22 @@ spec:
       - name: containerregistryelvia
       {{- end}}
       {{- if .Values.securityContext }}
-      securityContext: {{- toYaml .Values.securityContext | nindent 8 }} 
+      securityContext: {{- toYaml .Values.securityContext | nindent 8 }}
       {{- else }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+        readOnlyRootFilesystem: true
         runAsUser: 1001
         runAsGroup: 1001
         fsGroup: 1001
         supplementalGroups: [1001]
       {{- end }}
       {{- if .Values.dnsConfig }}
-      dnsConfig: {{- toYaml .Values.dnsConfig | nindent 8 }} 
+      dnsConfig: {{- toYaml .Values.dnsConfig | nindent 8 }}
       {{- end}}
       {{- with .Values.hostAliases }}
-      hostAliases: 
+      hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.volumes }}
@@ -136,7 +137,7 @@ spec:
         {{- with .Values.env }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ include "image" . }} 
+        image: {{ include "image" . }}
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false
@@ -236,7 +237,7 @@ spec:
         {{- end }}
       {{- if .Values.sidecars }}
       {{- range $sidecarKey, $sidecarValue := .Values.sidecars }}
-      {{- $data := dict "sidecar" $sidecarValue "tag" $.Values.image.tag "namespace" $.Values.namespace}}  
+      {{- $data := dict "sidecar" $sidecarValue "tag" $.Values.image.tag "namespace" $.Values.namespace}}
       - name: {{ required "Missing $sidecarValue.name" $sidecarValue.name }}
         env:
         - name: ELVIA_APPLICATION_NAMESPACE
@@ -250,7 +251,7 @@ spec:
         args:
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ include "sidecar.image" $data }}  
+        image: {{ include "sidecar.image" $data }}
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false
@@ -263,6 +264,3 @@ spec:
          {{end}}
         {{- end }}
       {{- end}}
-
-
-

--- a/elvia-statefulset/templates/statefulset.yaml
+++ b/elvia-statefulset/templates/statefulset.yaml
@@ -50,6 +50,7 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+        readOnlyRootFilesystem: true
         runAsUser: 1001
         runAsGroup: 1001
         fsGroup: 1001
@@ -71,7 +72,7 @@ spec:
         {{- with .Values.env }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ include "image" . }} 
+        image: {{ include "image" . }}
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false
@@ -84,7 +85,7 @@ spec:
             containerPort: {{ required "Missing $portsValue.containerPort" $portsValue.containerPort }}
             protocol: {{ required "Missing $portsValue.protocol" $portsValue.protocol }}
         {{- end}}
-        {{- end}}        
+        {{- end}}
         {{- with .Values.readinessProbe }}
         readinessProbe:
           {{- toYaml . | nindent 10 }}

--- a/iss-deployment/templates/deployment.yaml
+++ b/iss-deployment/templates/deployment.yaml
@@ -49,18 +49,19 @@ spec:
         traffic.sidecar.istio.io/excludeOutboundPorts: "9092"
     spec:
       serviceAccountName: {{ required "Missing .Values.name" .Values.name }}
-      securityContext:     
+      securityContext:
         fsGroup: 1001
+        readOnlyRootFilesystem: true
         runAsGroup: 1001
         runAsUser: 1001
         seccompProfile:
           type: RuntimeDefault
         supplementalGroups: [1001]
       {{- if .Values.dnsConfig }}
-      dnsConfig: {{- toYaml .Values.dnsConfig | nindent 8 }} 
+      dnsConfig: {{- toYaml .Values.dnsConfig | nindent 8 }}
       {{- end}}
       {{- with .Values.hostAliases }}
-      hostAliases: 
+      hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.volumes }}
@@ -80,7 +81,7 @@ spec:
         env:
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ include "image" . }} 
+        image: {{ include "image" . }}
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Rapportert som config audit `KSV014` av Trivy Operator.

Testet å deploye alle core-tjenester, det fungerer: https://github.com/3lvia/core/pull/304