### PR TITLE
Support environment-specific image-tags

### DIFF
--- a/elvia-deployment/Chart.yaml
+++ b/elvia-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.25.1
+version: 0.26.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/elvia-deployment/templates/_helpers.tpl
+++ b/elvia-deployment/templates/_helpers.tpl
@@ -99,8 +99,8 @@ or environment-specific:
 {{- $imagetag = .Values.image.dev.tag }}
 {{- end }}
 {{- if and (eq .Values.environment "test") .Values.image.test }}
-{{- $imagerepository = .Values.image.dev.repository }}
-{{- $imagTtag = .Values.image.dev.tag }}
+{{- $imagerepository = .Values.image.test.repository }}
+{{- $imagetag = .Values.image.test.tag }}
 {{- end }}
 {{- if and (eq .Values.environment "prod") .Values.image.prod }}
 {{- $imagerepository = .Values.image.prod.repository }}

--- a/elvia-deployment/templates/_helpers.tpl
+++ b/elvia-deployment/templates/_helpers.tpl
@@ -62,15 +62,57 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Define the image, using containerregistryelvia.azurecr.io as default container registry
+Define the image, using containerregistryelvia.azurecr.io as default container registry.
+
+Supports image for any environment:
+
+  image:
+    repository: myrepo
+    tag: mytag
+
+or environment-specific:
+
+  image:
+    sandbox:
+      repository: myrepo
+      tag: mytag
+    dev:
+      repository: myrepo
+      tag: mytag
+    test:
+      repository: myrepo
+      tag: mytag
+    prod:
+      repository: myrepo
+      tag: mytag
+
 */}}
 {{- define "image" -}}
+{{- $imagetag := .Values.image.tag }}
+{{- $imagerepository := .Values.image.repository }}
+{{- if and (eq .Values.environment "sandbox") .Values.image.sandbox }}
+{{- $imagerepository = .Values.image.sandbox.repository }}
+{{- $imagetag = .Values.image.sandbox.tag }}
+{{- end }}
+{{- if and (eq .Values.environment "dev") .Values.image.dev }}
+{{- $imagerepository = .Values.image.dev.repository }}
+{{- $imagetag = .Values.image.dev.tag }}
+{{- end }}
+{{- if and (eq .Values.environment "test") .Values.image.test }}
+{{- $imagerepository = .Values.image.dev.repository }}
+{{- $imagTtag = .Values.image.dev.tag }}
+{{- end }}
+{{- if and (eq .Values.environment "prod") .Values.image.prod }}
+{{- $imagerepository = .Values.image.prod.repository }}
+{{- $imagetag = .Values.image.prod.tag }}
+{{- end }}
 {{- if .Values.image.repository }}
-{{- .Values.image.repository }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- else }}:{{ required "Missing .Values.image.tag" .Values.image.tag }}{{- end }}
+{{- .Values.image.repository }}:{{ required (printf "Missing image.tag or image.%s.tag" .Values.environment) $imagetag }}
 {{- else }}
-{{- printf "containerregistryelvia.azurecr.io/%s-%s" .Values.namespace .Values.name }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- else }}:{{ required "Missing .Values.image.tag" .Values.image.tag }}{{- end }}
+{{- printf "containerregistryelvia.azurecr.io/%s-%s" .Values.namespace .Values.name }}:{{ required (printf "Missing image.tag or image.%s.tag" .Values.environment) $imagetag }}
 {{- end }}
 {{- end }}
+
 
 {{/*
 Define the sidecar.image, using containerregistryelvia.azurecr.io as default container registry

--- a/elvia-deployment/tests/__snapshot__/deployment_test.yaml.snap
+++ b/elvia-deployment/tests/__snapshot__/deployment_test.yaml.snap
@@ -66,3 +66,343 @@ deployment snapshot should match:
             supplementalGroups:
               - 1001
           serviceAccountName: demo-api
+deployment snapshot should match for dev-specific image when environment is dev:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: demo-api
+      namespace: core
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: demo-api
+          microservice-type: webapi
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            kubectl.kubernetes.io/default-container: demo-api
+          labels:
+            app: demo-api
+            azure.workload.identity/use: "true"
+            microservice-type: webapi
+        spec:
+          containers:
+            - env:
+                - name: ELVIA_APPLICATION_NAMESPACE
+                  value: core
+                - name: ELVIA_APPLICATION_NAME
+                  value: demo-api
+                - name: ELVIA_ENVIRONMENT
+                  value: dev
+                - name: ELVIA_WORKLOAD_IDENTITY_NAME
+                  value: uai-core-demo-api-dev
+                - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                  value: grpc
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  value: http://otel-collector.monitoring.svc.cluster.local:4317
+              image: containerregistryelvia.azurecr.io/core-demo-api:dev
+              imagePullPolicy: Always
+              name: demo-api
+              resources:
+                limits:
+                  cpu: 400m
+                  memory: 500Mi
+                requests:
+                  cpu: 50m
+                  memory: 100Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+          imagePullSecrets:
+            - name: containerregistryelvia
+          securityContext:
+            fsGroup: 1001
+            runAsGroup: 1001
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+            supplementalGroups:
+              - 1001
+          serviceAccountName: demo-api
+deployment snapshot should match for dev-specific image when environment isn't dev:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: demo-api
+      namespace: core
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: demo-api
+          microservice-type: webapi
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            kubectl.kubernetes.io/default-container: demo-api
+          labels:
+            app: demo-api
+            azure.workload.identity/use: "true"
+            microservice-type: webapi
+        spec:
+          containers:
+            - env:
+                - name: ELVIA_APPLICATION_NAMESPACE
+                  value: core
+                - name: ELVIA_APPLICATION_NAME
+                  value: demo-api
+                - name: ELVIA_ENVIRONMENT
+                  value: prod
+                - name: ELVIA_WORKLOAD_IDENTITY_NAME
+                  value: uai-core-demo-api-prod
+                - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                  value: grpc
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  value: http://otel-collector.monitoring.svc.cluster.local:4317
+              image: containerregistryelvia.azurecr.io/core-demo-api:latest
+              imagePullPolicy: Always
+              name: demo-api
+              resources:
+                limits:
+                  cpu: 400m
+                  memory: 500Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+          imagePullSecrets:
+            - name: containerregistryelvia
+          securityContext:
+            fsGroup: 1001
+            runAsGroup: 1001
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+            supplementalGroups:
+              - 1001
+          serviceAccountName: demo-api
+deployment snapshot should match for multiple images:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: demo-api
+      namespace: core
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: demo-api
+          microservice-type: webapi
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            kubectl.kubernetes.io/default-container: demo-api
+          labels:
+            app: demo-api
+            azure.workload.identity/use: "true"
+            microservice-type: webapi
+        spec:
+          containers:
+            - env:
+                - name: ELVIA_APPLICATION_NAMESPACE
+                  value: core
+                - name: ELVIA_APPLICATION_NAME
+                  value: demo-api
+                - name: ELVIA_ENVIRONMENT
+                  value: test
+                - name: ELVIA_WORKLOAD_IDENTITY_NAME
+                  value: uai-core-demo-api-test
+                - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                  value: grpc
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  value: http://otel-collector.monitoring.svc.cluster.local:4317
+              image: containerregistryelvia.azurecr.io/core-demo-api:test
+              imagePullPolicy: Always
+              name: demo-api
+              resources:
+                limits:
+                  cpu: 400m
+                  memory: 500Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+          imagePullSecrets:
+            - name: containerregistryelvia
+          securityContext:
+            fsGroup: 1001
+            runAsGroup: 1001
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+            supplementalGroups:
+              - 1001
+          serviceAccountName: demo-api
+deployment snapshot should match for prod-specific image when environment is prod:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: demo-api
+      namespace: core
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: demo-api
+          microservice-type: webapi
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            kubectl.kubernetes.io/default-container: demo-api
+          labels:
+            app: demo-api
+            azure.workload.identity/use: "true"
+            microservice-type: webapi
+        spec:
+          containers:
+            - env:
+                - name: ELVIA_APPLICATION_NAMESPACE
+                  value: core
+                - name: ELVIA_APPLICATION_NAME
+                  value: demo-api
+                - name: ELVIA_ENVIRONMENT
+                  value: prod
+                - name: ELVIA_WORKLOAD_IDENTITY_NAME
+                  value: uai-core-demo-api-prod
+                - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                  value: grpc
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  value: http://otel-collector.monitoring.svc.cluster.local:4317
+              image: containerregistryelvia.azurecr.io/core-demo-api:prod
+              imagePullPolicy: Always
+              name: demo-api
+              resources:
+                limits:
+                  cpu: 400m
+                  memory: 500Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+          imagePullSecrets:
+            - name: containerregistryelvia
+          securityContext:
+            fsGroup: 1001
+            runAsGroup: 1001
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+            supplementalGroups:
+              - 1001
+          serviceAccountName: demo-api
+deployment snapshot should match for test-specific image when environment is test:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: demo-api
+      namespace: core
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: demo-api
+          microservice-type: webapi
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            kubectl.kubernetes.io/default-container: demo-api
+          labels:
+            app: demo-api
+            azure.workload.identity/use: "true"
+            microservice-type: webapi
+        spec:
+          containers:
+            - env:
+                - name: ELVIA_APPLICATION_NAMESPACE
+                  value: core
+                - name: ELVIA_APPLICATION_NAME
+                  value: demo-api
+                - name: ELVIA_ENVIRONMENT
+                  value: test
+                - name: ELVIA_WORKLOAD_IDENTITY_NAME
+                  value: uai-core-demo-api-test
+                - name: OTEL_EXPORTER_OTLP_PROTOCOL
+                  value: grpc
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  value: http://otel-collector.monitoring.svc.cluster.local:4317
+              image: containerregistryelvia.azurecr.io/core-demo-api:test
+              imagePullPolicy: Always
+              name: demo-api
+              resources:
+                limits:
+                  cpu: 400m
+                  memory: 500Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+          imagePullSecrets:
+            - name: containerregistryelvia
+          securityContext:
+            fsGroup: 1001
+            runAsGroup: 1001
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+            supplementalGroups:
+              - 1001
+          serviceAccountName: demo-api

--- a/elvia-deployment/tests/deployment_test.yaml
+++ b/elvia-deployment/tests/deployment_test.yaml
@@ -19,3 +19,98 @@ tests:
           memory: 500Mi
     asserts:
       - matchSnapshot: {}
+
+  - it: deployment snapshot should match for dev-specific image when environment is dev
+    set:
+      image.dev.tag: dev
+      name: demo-api
+      namespace: core
+      microserviceType: webapi
+      environment: dev
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 400m
+          memory: 500Mi
+    asserts:
+      - matchSnapshot: {}
+
+  - it: deployment snapshot should match for test-specific image when environment is test
+    set:
+      image.test.tag: test
+      name: demo-api
+      namespace: core
+      microserviceType: webapi
+      environment: test
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 400m
+          memory: 500Mi
+    asserts:
+      - matchSnapshot: {}
+
+  - it: deployment snapshot should match for prod-specific image when environment is prod
+    set:
+      image.prod.tag: prod
+      name: demo-api
+      namespace: core
+      microserviceType: webapi
+      environment: prod
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 400m
+          memory: 500Mi
+    asserts:
+      - matchSnapshot: {}
+
+  - it: deployment snapshot should match for dev-specific image when environment isn't dev
+    set:
+      image.tag: latest
+      image.dev.tag: dev
+      name: demo-api
+      namespace: core
+      microserviceType: webapi
+      environment: prod
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 400m
+          memory: 500Mi
+    asserts:
+      - matchSnapshot: {}
+
+  - it: deployment snapshot should match for multiple images
+    set:
+      image.tag: latest
+      image.sandbox.tag: sandbox
+      image.dev.tag: dev
+      image.test.tag: test
+      image.prod.tag: prod
+      name: demo-api
+      namespace: core
+      microserviceType: webapi
+      environment: test
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 400m
+          memory: 500Mi
+    asserts:
+      - matchSnapshot: {}

--- a/elvia-statefulset/Chart.yaml
+++ b/elvia-statefulset/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.6
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/iss-deployment/Chart.yaml
+++ b/iss-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.5
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Tidlgere kunne man sette `image` slik:
```yaml
image:
  repository: containerregistryelvia.azurecr.io/core-demo-api
  tag: latest
```

Nå kan man også sette spesifikt per miljø. Faktisk gjeldende `image` blir tatt fra enten syntaks over eller fra der `image.<env>` er samme som verdi fra `environment`.

```yaml
image:
  sandbox:
    repository: containerregistryelvia.azurecr.io/core-demo-api
    tag: sandbox
  dev:
    repository: containerregistryelvia.azurecr.io/core-demo-api
    tag: dev
  test:
    repository: containerregistryelvia.azurecr.io/core-demo-api
    tag: test
  prod:
    repository: containerregistryelvia.azurecr.io/core-demo-api
    tag: prod
```

Dette er for å tilrettelegge for deploy med Argo CD.