### PR TITLE
Override image.repository if on old format

### DIFF
--- a/elvia-deployment/Chart.yaml
+++ b/elvia-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.27.0
+version: 0.27.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/elvia-deployment/templates/_helpers.tpl
+++ b/elvia-deployment/templates/_helpers.tpl
@@ -106,7 +106,7 @@ or environment-specific:
 {{- $imagerepository = .Values.image.prod.repository }}
 {{- $imagetag = .Values.image.prod.tag }}
 {{- end }}
-{{- if .Values.image.repository }}
+{{- if and .Values.image.repository (ne .Values.image.repository (printf "containerregistryelvia.azurecr.io/%s-%s" .Values.namespace .Values.name)) }} # only allow setting image repo if it is not on old deprecated syntax
 {{- .Values.image.repository }}:{{ required (printf "Missing image.tag or image.%s.tag" .Values.environment) $imagetag }}
 {{- else }}
 {{- printf "containerregistryelvia.azurecr.io/%s/%s" .Values.namespace .Values.name }}:{{ required (printf "Missing image.tag or image.%s.tag" .Values.environment) $imagetag }}

--- a/elvia-deployment/templates/_helpers.tpl
+++ b/elvia-deployment/templates/_helpers.tpl
@@ -67,7 +67,6 @@ Define the image, using containerregistryelvia.azurecr.io as default container r
 Supports image for any environment:
 
   image:
-    repository: myrepo
     tag: mytag
 
 or environment-specific:

--- a/elvia-statefulset/Chart.yaml
+++ b/elvia-statefulset/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0
+version: 0.11.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/elvia-statefulset/templates/_helpers.tpl
+++ b/elvia-statefulset/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 Define the image, using containerregistryelvia.azurecr.io as default container registry
 */}}
 {{- define "image" -}}
-{{- if .Values.image.repository }}
+{{- if and .Values.image.repository (ne .Values.image.repository (printf "containerregistryelvia.azurecr.io/%s-%s" .Values.namespace .Values.name)) }} # only allow setting image repo if it is not on old deprecated syntax
 {{- .Values.image.repository }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- else }}:{{ required "Missing .Values.image.tag" .Values.image.tag }}{{- end }}
 {{- else }}
 {{- printf "containerregistryelvia.azurecr.io/%s/%s" .Values.namespace .Values.name }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- else }}:{{ required "Missing .Values.image.tag" .Values.image.tag }}{{- end }}


### PR DESCRIPTION
Lar deg bare sette `image.repository` dersom den ikke er på gammel syntaks med bindestrek mellom system og navn.